### PR TITLE
add support for '''devops''' repos (SOFTWARE-3291)

### DIFF
--- a/bin/new_mashfile.sh
+++ b/bin/new_mashfile.sh
@@ -3,11 +3,11 @@
 usage () {
   echo "Usage: $(basename "$0") TAG [DESTDIR]"
   echo "Where:"
-  echo "  TAG is osg-SERIES-DVER-REPO or goc-DVER-REPO"
+  echo "  TAG is osg-SERIES-DVER-REPO or devops-DVER-REPO"
   echo "  SERIES is: 3.1, 3.2, etc, or upcoming"
   echo "  DVER is: el5, el6, etc."
   echo "  REPO is: contrib, development, testing, or release for osg"
-  echo "       or: itb or production for goc"
+  echo "       or: itb or production for devops (formerly goc)"
   echo "  DESTDIR defaults to /etc/mash/"
   echo
   echo "Writes DESTDIR/TAG.mash"
@@ -27,6 +27,7 @@ title () { python -c 'import sys; print sys.argv[1].title()' "$*" ; }
 TAG=$1
 case $TAG in
   osg-*-*-* ) IFS='-' read osg SERIES DVER REPO <<< "$TAG" ;;
+  devops-*-*| \
   goc-*-*   ) IFS='-' read SERIES DVER REPO <<< "$TAG" ;;
           * ) usage ;;
 esac

--- a/bin/update_mashfiles.sh
+++ b/bin/update_mashfiles.sh
@@ -54,9 +54,11 @@ else
   osg_repopat='contrib|development|release|rolling|testing|empty'
   osg_tagpat="osg-($osg_seriespat)-el[5-9]-($osg_repopat)"
   goc_tagpat='goc-el[5-9]-(itb|production)'
+  devops_tagpat='devops-el[7-9]-(itb|production)'
 
   koji --config=/etc/mash_koji_config list-tags 'osg-*-*-*' 'goc-*-*' \
-  | egrep -xe "$osg_tagpat" -e "$goc_tagpat"                          \
+                                                'devops-*-*'          \
+  | egrep -xe "$osg_tagpat" -e "$goc_tagpat" -e "$devops_tagpat"      \
   | fgrep -vxf $OSGTAGS.exclude > $OSGTAGS.new || :
 
   if [[ -s $OSGTAGS.new ]]; then

--- a/bin/update_repo.sh
+++ b/bin/update_repo.sh
@@ -4,11 +4,11 @@
 usage () {
   echo "Usage: $(basename "$0") TAG"
   echo "Where:"
-  echo "  TAG is osg-SERIES-DVER-REPO or goc-DVER-REPO"
+  echo "  TAG is osg-SERIES-DVER-REPO or devops-DVER-REPO"
   echo "  SERIES is: 3.1, 3.2, etc, or upcoming"
   echo "  DVER is: el5, el6, etc."
   echo "  REPO is: contrib, development, testing, or release for osg"
-  echo "       or: itb or production for goc"
+  echo "       or: itb or production for devops (formerly goc)"
   echo "  DESTDIR defaults to /etc/mash/"
   exit 1
 }
@@ -18,6 +18,7 @@ TAG=$1
 
 case $TAG in
   osg-*-*-* ) IFS='-' read osg SERIES DVER REPO <<< "$TAG" ;;
+  devops-*-*| \
   goc-*-*   ) IFS='-' read SERIES DVER REPO <<< "$TAG" ;;
           * ) usage ;;
 esac

--- a/rpm/osg-repo-scripts.spec
+++ b/rpm/osg-repo-scripts.spec
@@ -1,5 +1,5 @@
 Name:		osg-repo-scripts
-Version:	1.3
+Version:	1.4
 Release:	1%{?dist}
 Summary:	rpm repo update scripts for osg repo servers
 
@@ -68,6 +68,9 @@ install -m 0644 share/repo/mash.template $RPM_BUILD_ROOT%{_datadir}/repo/
 %dir               %{_usr}/local/mirror
 
 %changelog
+* Mon Aug 05 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.4-1
+- Add support for devops repos (SOFTWARE-3291)
+
 * Mon Feb 11 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.3-1
 - Add support for rolling release repos (SOFTWARE-3465)
 


### PR DESCRIPTION
These are going to take on the role of the former `goc` repos, plus include osg developer packages.  For now, we'll support both, to ease the transition and not have to mess with the osg-3.4 repos.

I take absolutely no credit for the new `devops` name.