### PR TITLE
mirrorlist symlink 3.5-upcoming -> upcoming (SOFTWARE-4420)

### DIFF
--- a/bin/update_mirror.py
+++ b/bin/update_mirror.py
@@ -117,6 +117,9 @@ for tag in tags:
             f.write(m+"\n")
         f.close()
 
+# SOFTWARE-4420: temporary 3.5-upcoming symlink to upcoming
+os.symlink("/usr/local/mirror/.osg.new/3.5-upcoming", "upcoming")
+
 #point mirror to new
 os.unlink("/usr/local/mirror/osg")
 os.symlink(".osg.new", "/usr/local/mirror/osg")

--- a/rpm/osg-repo-scripts.spec
+++ b/rpm/osg-repo-scripts.spec
@@ -1,5 +1,5 @@
 Name:		osg-repo-scripts
-Version:	1.6
+Version:	1.7
 Release:	1%{?dist}
 Summary:	rpm repo update scripts for osg repo servers
 
@@ -68,6 +68,9 @@ install -m 0644 share/repo/mash.template $RPM_BUILD_ROOT%{_datadir}/repo/
 %dir               %{_usr}/local/mirror
 
 %changelog
+* Fri Jan 15 2021 Carl Edquist <edquist@cs.wisc.edu> - 1.7-1
+- Create mirror/osg/3.5-upcoming -> upcoming symlink (SOFTWARE-4420)
+
 * Thu Oct 29 2020 Carl Edquist <edquist@cs.wisc.edu> - 1.6-1
 - Include non-latest packages in rolling repos (SOFTWARE-4270)
 


### PR DESCRIPTION
The mirror/osg dir gets regenerated every time the script is run, so we need to create this symlink every time.