### PR TITLE
fix symlink src/dest (SOFTWARE-4420)

### DIFF
--- a/bin/update_mirror.py
+++ b/bin/update_mirror.py
@@ -118,7 +118,7 @@ for tag in tags:
         f.close()
 
 # SOFTWARE-4420: temporary 3.5-upcoming symlink to upcoming
-os.symlink("/usr/local/mirror/.osg.new/3.5-upcoming", "upcoming")
+os.symlink("upcoming", "/usr/local/mirror/.osg.new/3.5-upcoming")
 
 #point mirror to new
 os.unlink("/usr/local/mirror/osg")

--- a/rpm/osg-repo-scripts.spec
+++ b/rpm/osg-repo-scripts.spec
@@ -1,5 +1,5 @@
 Name:		osg-repo-scripts
-Version:	1.7
+Version:	1.8
 Release:	1%{?dist}
 Summary:	rpm repo update scripts for osg repo servers
 
@@ -68,7 +68,7 @@ install -m 0644 share/repo/mash.template $RPM_BUILD_ROOT%{_datadir}/repo/
 %dir               %{_usr}/local/mirror
 
 %changelog
-* Fri Jan 15 2021 Carl Edquist <edquist@cs.wisc.edu> - 1.7-1
+* Fri Jan 15 2021 Carl Edquist <edquist@cs.wisc.edu> - 1.8-1
 - Create mirror/osg/3.5-upcoming -> upcoming symlink (SOFTWARE-4420)
 
 * Thu Oct 29 2020 Carl Edquist <edquist@cs.wisc.edu> - 1.6-1


### PR DESCRIPTION
'src' is the target of the symlink, 'dst' is the symlink filename ... i guess it's easy enough to mix the two up.

I actually tested this one and it works now:
http://repo.opensciencegrid.org/mirror/osg/