### PR TITLE
Update production repos first (SOFTWARE-5441)

### DIFF
--- a/bin/update_all_repos.sh
+++ b/bin/update_all_repos.sh
@@ -42,7 +42,7 @@ if ! flock -n 299; then
 fi
 
 datemsg "Updating all mash repos..."
-for tag in $(< $OSGTAGS); do
+for tag in $(tac $OSGTAGS); do
   datemsg "Running update_repo.sh for tag $tag ..."
   ./update_repo.sh "$tag" > "$LOGDIR/update_repo.$tag.log" \
                          2> "$LOGDIR/update_repo.$tag.err" \


### PR DESCRIPTION
If we've got a critical repo failure, we want to build the latest OSG release series first and not the devops + oldest OSG release series