### PR TITLE
Disable lftp SSL verification

### DIFF
--- a/etc/lftp.conf
+++ b/etc/lftp.conf
@@ -1,0 +1,3 @@
+# EL8 lftp-4.8.4-2.el8.x86_64 doesn't include cert chain verification fix
+# https://github.com/lavv17/lftp/issues/641
+set ssl:verify-certificate no


### PR DESCRIPTION
EL8 lftp-4.8.4-2.el8.x86_64 doesn't include a cert chain verification patch. If the chain is incorrectly ordered or uses a cross-signed certificate, validation might fail.