### PR TITLE
OPS-332: tail all cron job output to the init process's stdout for k8s logging

### DIFF
--- a/99-tail-cron-logs.sh
+++ b/99-tail-cron-logs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Tail all of the logs from cron jobs to the init process's stdout so they show up in Kubernetes logs
+
+# Pre-populate log directories and files so there's something to tail
+mkdir -p /var/log/repo
+touch /var/log/repo/update_mirror.log
+touch /var/log/repo/update_all_repos.log
+touch /var/log/repo/update_mashfiles.log
+
+# Tail the logs in the background 
+# Note: This is very fragile, requires append-only operations to every log file
+tail -f /var/log/repo/*.log &

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN \
 # supervisord and cron configs
 COPY docker/supervisor-*.conf /etc/supervisord.d/
 COPY docker/*.cron /etc/cron.d/
+COPY 99-tail-cron-logs.sh /etc/osg/image-init.d/
 
 # OSG scripts for repo maintenance
 COPY bin/* /usr/bin/

--- a/bin/update_all_repos.sh
+++ b/bin/update_all_repos.sh
@@ -12,6 +12,10 @@ datemsg () {
   echo "$(date):" "$@"
 }
 
+prepend_tag() {
+  while read line; do echo "${1}${line}"; done;
+}
+
 # cd /usr/local
 cd "$(dirname "$0")"
 LOGDIR=/var/log/repo
@@ -45,8 +49,7 @@ failed=0
 datemsg "Updating all mash repos..."
 for tag in $(tac $OSGTAGS); do
   datemsg "Running update_repo.sh for tag $tag ..."
-  if ! ./update_repo.sh "$tag" > "$LOGDIR/update_repo.$tag.log" \
-                              2> "$LOGDIR/update_repo.$tag.err"; then
+  if ! ./update_repo.sh "$tag" 2>&1 | prepend_tag "[update_repo.sh $tag] "; then
     datemsg "mash failed for $tag - please see error log" >&2
     failed=1
   fi

--- a/bin/update_mirror.py
+++ b/bin/update_mirror.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import urllib2
 import time
 import sys
@@ -10,7 +11,7 @@ import fcntl
 import errno
 
 def log(log):
-    print time.strftime("%a %m/%d/%y %H:%M:%S %Z: ", time.localtime()),log
+    print("[%s]"%sys.argv[0], time.strftime("%a %m/%d/%y %H:%M:%S %Z: ", time.localtime()), log)
 
 def lock(path):
     dir = os.path.dirname(path)

--- a/etc/cron.d/repo
+++ b/etc/cron.d/repo
@@ -1,9 +1,10 @@
 #update all .mash files, once daily
-@reboot    root /usr/bin/update_mashfiles.sh > /var/log/repo/update_mashfiles.log 2> /var/log/repo/update_mashfiles.err
-50 7 * * * root /usr/bin/update_mashfiles.sh > /var/log/repo/update_mashfiles.log 2> /var/log/repo/update_mashfiles.err
+@reboot    root /usr/bin/update_mashfiles.sh >> /var/log/repo/update_mashfiles.log 2>&1 
+50 7 * * * root /usr/bin/update_mashfiles.sh >> /var/log/repo/update_mashfiles.log 2>&1 
 
 #update all mash repos, every half-hour
-1-59/30 * * * * root /usr/bin/update_all_repos.sh > /var/log/repo/update_all_repos.log 2> /var/log/repo/update_all_repos.err
+1-59/30 * * * * root /usr/bin/update_all_repos.sh >> /var/log/repo/update_all_repos.log 2>&1 
 
 #update mirror
-29-59/30 * * * *  root /usr/bin/update_mirror.py > /var/log/repo/update_mirror.log 2> /var/log/repo/update_mirror.err
+29-59/30 * * * *  root /usr/bin/update_mirror.py >> /var/log/repo/update_mirror.log 2>&1 
+


### PR DESCRIPTION
Previously each stdout and stderr for every argument `update_repo.sh` got its own log file. This change also consolidates them down into the single `update_all_repos.log` for ease of access, and prepends the name of the repo being updated to each line of log output