### PR TITLE
SOFTWARE-5621: osg 23 naming conventions

### DIFF
--- a/bin/new_mashfile.sh
+++ b/bin/new_mashfile.sh
@@ -26,8 +26,8 @@ title () { python -c 'import sys; print sys.argv[1].title()' "$*" ; }
 
 TAG=$1
 case $TAG in
-  osg-3.*-upcoming-*-* ) IFS='-' read osg SERIES upcoming DVER REPO <<< "$TAG"
-                         SERIES+=-$upcoming ;;
+  osg-*-*-*-* ) IFS='-' read osg SERIES branch DVER REPO <<< "$TAG"
+                         SERIES+=-$branch ;;
   osg-*-*-* ) IFS='-' read osg SERIES DVER REPO <<< "$TAG" ;;
   devops-*-*) IFS='-' read SERIES DVER REPO <<< "$TAG" ;;
           * ) usage ;;

--- a/bin/update_mashfiles.sh
+++ b/bin/update_mashfiles.sh
@@ -50,7 +50,7 @@ else
 
   [[ -e $OSGTAGS.exclude ]] || touch $OSGTAGS.exclude
 
-  osg_seriespat='[0-9]+\.[0-9]+(-upcoming)?'
+  osg_seriespat='([0-9]+\.[0-9]+|[2-9][0-9])(-upcoming|-main)?'
   osg_repopat='contrib|development|release|rolling|testing|empty'
   osg_tagpat="osg-($osg_seriespat)-el[5-9]-($osg_repopat)"
   devops_tagpat='devops-el[7-9]-(itb|production)'

--- a/bin/update_mirror.py
+++ b/bin/update_mirror.py
@@ -9,6 +9,7 @@ import shutil
 import socket
 import fcntl
 import errno
+import re
 
 def log(log):
     print("[%s]"%sys.argv[0], time.strftime("%a %m/%d/%y %H:%M:%S %Z: ", time.localtime()), log)
@@ -58,9 +59,9 @@ if socket.gethostname() == "repo-itb.opensciencegrid.org":
     hostname="repo-itb.opensciencegrid.org"
 
 def tagsplit(tag):
-    if 'upcoming' in tag and tag.startswith("osg-3."):
-        series,_,dver,repo = tag.split('-')[-4:]
-        series += "-upcoming"
+    if re.match(r'osg-[0-9.]*-[a-z]*-el[0-9]+-[a-z]*', tag):
+        series,branch,dver,repo = tag.split('-')[-4:]
+        series += "-" + branch
     else:
         series,dver,repo = tag.split('-')[-3:]
     return series,dver,repo

--- a/bin/update_repo.sh
+++ b/bin/update_repo.sh
@@ -17,8 +17,6 @@ usage () {
 TAG=$1
 
 case $TAG in
-  osg-3.*-upcoming-*-* ) IFS='-' read osg SERIES upcoming DVER REPO <<< "$TAG"
-                         SERIES+=-$upcoming ;;
   osg-*-*-*-* ) IFS='-' read osg SERIES branch DVER REPO <<< "$TAG"
                          SERIES+=-$branch ;;
   osg-*-*-* ) IFS='-' read osg SERIES DVER REPO <<< "$TAG" ;;

--- a/bin/update_repo.sh
+++ b/bin/update_repo.sh
@@ -19,6 +19,8 @@ TAG=$1
 case $TAG in
   osg-3.*-upcoming-*-* ) IFS='-' read osg SERIES upcoming DVER REPO <<< "$TAG"
                          SERIES+=-$upcoming ;;
+  osg-*-*-*-* ) IFS='-' read osg SERIES branch DVER REPO <<< "$TAG"
+                         SERIES+=-$branch ;;
   osg-*-*-* ) IFS='-' read osg SERIES DVER REPO <<< "$TAG" ;;
   devops-*-*) IFS='-' read SERIES DVER REPO <<< "$TAG" ;;
           * ) usage ;;


### PR DESCRIPTION
Updates the four scripts in bin/ to handle the `osg-23-main-...` cag naming covention. Tested to still work with `osg-3.6...`, lightly tested against the existing empty `osg-23` tags currently in koji.