### PR TITLE
SOFTWARE-5678: Update scripts to create top-level 23-empty/contrib repos

### DIFF
--- a/bin/new_mashfile.sh
+++ b/bin/new_mashfile.sh
@@ -28,6 +28,7 @@ TAG=$1
 case $TAG in
   osg-*-*-*-* ) IFS='-' read osg SERIES branch DVER REPO <<< "$TAG"
                          SERIES+=-$branch ;;
+  # matches osg-2X-elY-empty and contrib, but not the equivalent 3.X tags
   osg-[1-9][^.]*-*-empty|osg-[1-9][^.]*-*-contrib )
                 IFS='-' read osg SERIES DVER REPO <<< "$TAG"
                 SERIES+=-$REPO 

--- a/bin/new_mashfile.sh
+++ b/bin/new_mashfile.sh
@@ -28,6 +28,10 @@ TAG=$1
 case $TAG in
   osg-*-*-*-* ) IFS='-' read osg SERIES branch DVER REPO <<< "$TAG"
                          SERIES+=-$branch ;;
+  osg-[1-9][^.]*-*-empty|osg-[1-9][^.]*-*-contrib )
+                IFS='-' read osg SERIES DVER REPO <<< "$TAG"
+                SERIES+=-$REPO 
+                REPO='' ;;
   osg-*-*-* ) IFS='-' read osg SERIES DVER REPO <<< "$TAG" ;;
   devops-*-*) IFS='-' read SERIES DVER REPO <<< "$TAG" ;;
           * ) usage ;;

--- a/bin/update_mirror.py
+++ b/bin/update_mirror.py
@@ -62,6 +62,10 @@ def tagsplit(tag):
     if re.match(r'osg-[0-9.]*-[a-z]*-el[0-9]+-[a-z]*', tag):
         series,branch,dver,repo = tag.split('-')[-4:]
         series += "-" + branch
+    elif re.match(r'osg-[0-9][^.][0-9]*-el[0-9]+-(contrib|empty)', tag):
+        series,dver,repo = tag.split('-')[-3:]
+        series += "-" + repo
+        repo = ''
     else:
         series,dver,repo = tag.split('-')[-3:]
     return series,dver,repo

--- a/bin/update_mirror.py
+++ b/bin/update_mirror.py
@@ -62,6 +62,7 @@ def tagsplit(tag):
     if re.match(r'osg-[0-9.]*-[a-z]*-el[0-9]+-[a-z]*', tag):
         series,branch,dver,repo = tag.split('-')[-4:]
         series += "-" + branch
+    # matches osg-2X-elY-empty and contrib, but not the equivalent 3.X tags
     elif re.match(r'osg-[0-9][^.][0-9]*-el[0-9]+-(contrib|empty)', tag):
         series,dver,repo = tag.split('-')[-3:]
         series += "-" + repo

--- a/bin/update_repo.sh
+++ b/bin/update_repo.sh
@@ -19,6 +19,10 @@ TAG=$1
 case $TAG in
   osg-*-*-*-* ) IFS='-' read osg SERIES branch DVER REPO <<< "$TAG"
                          SERIES+=-$branch ;;
+  osg-[1-9][^.]*-*-empty|osg-[1-9][^.]*-*-contrib )
+                IFS='-' read osg SERIES DVER REPO <<< "$TAG"
+                SERIES+=-$REPO
+                REPO='' ;;
   osg-*-*-* ) IFS='-' read osg SERIES DVER REPO <<< "$TAG" ;;
   devops-*-*) IFS='-' read SERIES DVER REPO <<< "$TAG" ;;
           * ) usage ;;

--- a/bin/update_repo.sh
+++ b/bin/update_repo.sh
@@ -19,6 +19,7 @@ TAG=$1
 case $TAG in
   osg-*-*-*-* ) IFS='-' read osg SERIES branch DVER REPO <<< "$TAG"
                          SERIES+=-$branch ;;
+  # matches osg-2X-elY-empty and contrib, but not the equivalent 3.X tags
   osg-[1-9][^.]*-*-empty|osg-[1-9][^.]*-*-contrib )
                 IFS='-' read osg SERIES DVER REPO <<< "$TAG"
                 SERIES+=-$REPO


### PR DESCRIPTION
Updates scripts to create top-level 23-empty/contrib repos, rather than creating sub-repos of 23-main