### PR TITLE
Update mash koji config for new KojiHub

### DIFF
--- a/etc/mash_koji_config
+++ b/etc/mash_koji_config
@@ -1,8 +1,8 @@
 [koji]
 ;configuration for koji cli tool
 ;url of XMLRPC server
-server = http://koji.chtc.wisc.edu/kojihub
+server = https://koji.osg-htc.org/kojihub
 ;url of web interface
-weburl = http://koji.chtc.wisc.edu/koji
+weburl = https://koji.osg-htc.org/koji
 ;path to the koji top directory
 topdir = /mnt/koji


### PR DESCRIPTION
Otherwise, I see the following:

```
2023-09-29 18:28:38,264 [ERROR] koji: HTTPError: 405 Client Error: Method Not Allowed for url: https://koji.osg-htc.org/kojihub
```