### PR TITLE
FIXME: temporarily disable development RPMs

### DIFF
--- a/etc/osg-koji-tags/osg-tags.exclude
+++ b/etc/osg-koji-tags/osg-tags.exclude
@@ -40,3 +40,7 @@ osg-3.5-upcoming-el8-development
 osg-3.5-upcoming-el8-release
 osg-3.5-upcoming-el8-rolling
 osg-3.5-upcoming-el8-testing
+osg-23-main-el8-development
+osg-23-main-el9-development
+osg-23-upcoming-el8-development
+osg-23-upcoming-el9-development


### PR DESCRIPTION
This is causing issues with testing/release repos because mash runs against development, pulling down RPMs signed with the auto key, which is not what is expected for testing/release.

We can remove this once we update the mash scripts to use a different mash cache for development repos