### PR TITLE
Drop --exclude=3.2 argument from lftp invocation

### DIFF
--- a/bin/update_tarball-install.sh
+++ b/bin/update_tarball-install.sh
@@ -11,7 +11,6 @@ DEST=/usr/local/repo/tarball-install
   --exclude-glob=osg-afs-client-*         `# Skip osg-afs-client`    \
   --exclude-glob=*tarballs.rescue         `# Ignore rescue tarballs` \
   --exclude-glob=osg-wn-client-latest.*   `# Ignore latest symlinks` \
-  --exclude=3.2                           `# Exclude old releases`   \
   https://vdt.cs.wisc.edu/tarball-client/                            \
   $DEST
 


### PR DESCRIPTION
it was matching this
```
osg-wn-client-23.231003-1.el8.x86_64.tar.gz
               ^^^
```
and excluding the osg 23 tarballs