### PR TITLE
Put back the --exclude=3.2 line but make sure it only excludes the directory named "3.2"

### DIFF
--- a/bin/update_tarball-install.sh
+++ b/bin/update_tarball-install.sh
@@ -11,6 +11,7 @@ DEST=/usr/local/repo/tarball-install
   --exclude-glob=osg-afs-client-*         `# Skip osg-afs-client`    \
   --exclude-glob=*tarballs.rescue         `# Ignore rescue tarballs` \
   --exclude-glob=osg-wn-client-latest.*   `# Ignore latest symlinks` \
+  --exclude='(^|/)3\.2(/|$)'              `# Ignore "3.2" volume mount` \
   https://vdt.cs.wisc.edu/tarball-client/                            \
   $DEST
 


### PR DESCRIPTION
The 3.2 directory is an AFS mount point so I can't just "rmdir" it.  --exclude is a regexp.