### PR TITLE
SOFTWARE-5708: Fail update_repo if pull_condor_rpms fails

### DIFF
--- a/bin/pull_condor_rpms.sh
+++ b/bin/pull_condor_rpms.sh
@@ -21,18 +21,18 @@ usage () {
 }
 
 tag_not_supported() {
-    echo "Tag $TAG does not have a corresponding condor version."
-    exit 0
+    echo "Tag $TAG does not have a corresponding condor version. Nothing to do."
+    exit 2
 }
 
 branch_not_supported() {
-    echo "Branch $1 does not have a corresponding condor branch."
-    exit 1
+    echo "Branch $1 does not have a corresponding condor branch. Nothing to do."
+    exit 2
 }
 
 repo_not_supported() {
-    echo "Repo $1 does not have a corresponding condor repo."
-    exit 1
+    echo "Repo $1 does not have a corresponding condor repo. Nothing to do."
+    exit 2
 }
 
 [[ $# -eq 4 ]] || usage
@@ -62,7 +62,7 @@ esac
 # development -> daily
 case $REPO in
     release ) CONDOR_REPOS=(release) ;;
-    testing ) CONDOR_REPOS=${TESTING_CONDOR_REPOS[@]} ;;
+    testing ) CONDOR_REPOS=(${TESTING_CONDOR_REPOS[@]}) ;;
     development ) CONDOR_REPOS=(daily) ;;
     * ) repo_not_supported $REPO ;;
 esac
@@ -75,6 +75,7 @@ for CONDOR_REPO in ${CONDOR_REPOS[@]}; do
   RSYNC_URL="$RSYNC_ROOT/$CONDOR_SERIES/$DVER/x86_64/$CONDOR_REPO/$SOURCE_SET*.rpm"
   echo "rsyncing $RSYNC_URL to $NEW_REPO_DIR"
   if ! rsync --times $RSYNC_URL $NEW_REPO_DIR --link-dest $CURRENT_REPO_DIR; then
-    echo "Warning: No packages found for $RSYNC_URL. Skipping"
+    echo "Error: No packages found for $RSYNC_URL."
+    exit 1
   fi
 done

--- a/bin/pull_condor_rpms.sh
+++ b/bin/pull_condor_rpms.sh
@@ -74,14 +74,17 @@ mkdir -p $CURRENT_REPO_DIR
 for CONDOR_REPO in ${CONDOR_REPOS[@]}; do
   RSYNC_URL="$RSYNC_ROOT/$CONDOR_SERIES/$DVER/x86_64/$CONDOR_REPO/$SOURCE_SET*.rpm"
   echo "rsyncing $RSYNC_URL to $NEW_REPO_DIR"
-  rsync_tmpfile=$(mktemp rsync.XXXXXX)
 
+  rsync_tmpfile=$(mktemp rsync.XXXXXX)
   rsync --list-only "$RSYNC_URL" > "$rsync_tmpfile"
   ret=$?
+  file_count=$(wc -l < "$rsync_tmpfile")
+  rm $rsync_tmpfile
+
   if [[ $ret != 0 ]]; then
     echo "Unable to get directory listing for $RSYNC_URL: rsync failed with exit code $ret"
     exit 1
-  elif [[ $(wc -l "$rsync_tmpfile") == 0 ]]; then
+  elif [[ $file_count == 0 ]]; then
     echo "Directory listing for $RSYNC_URL returned no files"
     exit 1
   fi

--- a/bin/update_repo.sh
+++ b/bin/update_repo.sh
@@ -63,19 +63,27 @@ if [ "$?" -ne "0" ]; then
         exit 1
 fi
 
+pull_condor_rpms.sh $TAG $repo_working_path $repo_release_path ''
+CONDOR_SYNC_EXIT=$?
 # Copy relevant htcondor rpms to the working directory, if any
-if pull_condor_rpms.sh $TAG $repo_working_path $repo_release_path '' ; then
-        # if htcondor rpms were copied, we need to regenerate the repo files
-        createrepo --update $repo_working_path
-        repoview $repo_working_path
-fi
+case $CONDOR_SYNC_EXIT in
+  0 ) createrepo --update $repo_working_path
+      repoview $repo_working_path ;;
+  1 ) echo "Error: Condor repo sync failed"
+      exit 1 ;;
+  * ) echo "Nothing to be done for condor repo sync" ;;
+esac
 
+pull_condor_rpms.sh $TAG $repo_working_srpm_path $repo_release_srpm_path 'SRPMS/'
+CONDOR_SRPM_SYNC_EXIT=$?
 # Copy relevant htcondor srpms to the working directory, if any
-if pull_condor_rpms.sh $TAG $repo_working_srpm_path $repo_release_srpm_path 'SRPMS/' ; then
-        # if htcondor srpms were copied, we need to regenerate the repo files
-        createrepo --update $repo_working_srpm_path
-        repoview $repo_working_srpm_path
-fi
+case $CONDOR_SRPM_SYNC_EXIT in
+  0 ) createrepo --update $repo_working_srpm_path
+      repoview $repo_working_srpm_path ;;
+  1 ) echo "Error: Condor srpm repo sync failed" 
+      exit 1 ;;
+  * ) echo "Nothing to be done for condor srpm repo sync" ;;
+esac
 
 rm -rf "$previous_path"
 mv "$release_path" "$previous_path"


### PR DESCRIPTION
- Update pull_condor_rpms.sh to return exit code 0 if it successfully rsynced rpms, 1 if something goes wrong, and 2 if it determines no action is needed
- Update update_repo.sh to check the specific exit code of pull_condor_rpms and act accordingly