### PR TITLE
Downgrade attempting to rsync an empty condor repo from an error to a warning

### DIFF
--- a/bin/pull_condor_rpms.sh
+++ b/bin/pull_condor_rpms.sh
@@ -70,21 +70,22 @@ esac
 mkdir -p $CURRENT_REPO_DIR
 
 for CONDOR_REPO in ${CONDOR_REPOS[@]}; do
-  RSYNC_URL="$RSYNC_ROOT/$CONDOR_SERIES/$DVER/x86_64/$CONDOR_REPO/$SOURCE_SET*.rpm"
+  RSYNC_DIR_URL="$RSYNC_ROOT/$CONDOR_SERIES/$DVER/x86_64/$CONDOR_REPO/$SOURCE_SET"
+  RSYNC_URL="$RSYNC_DIR_URL*.rpm"
   echo "rsyncing $RSYNC_URL to $NEW_REPO_DIR"
 
   rsync_tmpfile=$(mktemp rsync.XXXXXX)
-  rsync --list-only "$RSYNC_URL" > "$rsync_tmpfile"
+  rsync --list-only "$RSYNC_DIR_URL" > "$rsync_tmpfile"
   ret=$?
-  file_count=$(wc -l < "$rsync_tmpfile")
+  file_count=$(grep ".rpm$" "$rsync_tmpfile" | wc -l)
   rm $rsync_tmpfile
 
   if [[ $ret != 0 ]]; then
-    echo "Unable to get directory listing for $RSYNC_URL: rsync failed with exit code $ret"
+    echo "Unable to get directory listing for $RSYNC_DIR_URL: rsync failed with exit code $ret"
     exit 1
   elif [[ $file_count == 0 ]]; then
-    echo "Directory listing for $RSYNC_URL returned no files"
-    exit 1
+    echo "Directory listing for $RSYNC_URL returned no files. Nothing to do."
+    exit 2
   fi
 
   rsync --times $RSYNC_URL $NEW_REPO_DIR --link-dest $CURRENT_REPO_DIR


### PR DESCRIPTION
- Code for this was already in place but was broken, since `rsync --list-only` still returns a nonzero exit code when no files are returned
- Doing the first list-only at the directory level rather than "*.rpm" will return a non-zero exit code if the directory exists but is empty, since it returns the single result containing the directory itself
- Need to grep specifically for rpms in the later check for whether the directory has content