### PR TITLE
Fix RPM signatures in 23-empty and 23-contrib repos

### DIFF
--- a/bin/new_mashfile.sh
+++ b/bin/new_mashfile.sh
@@ -74,7 +74,7 @@ esac
 
 # In OSG 23+, we have a separate signing key for development versus
 # promoted packages.
-if [[ $REPO == development || $REPO == contrib ]]; then
+if [[ $REPO == development ]]; then
     KEYS=$auto_key
 else
     KEYS=$developer_key

--- a/bin/new_mashfile.sh
+++ b/bin/new_mashfile.sh
@@ -75,8 +75,8 @@ esac
 # In OSG 23+, we have a separate signing key for development versus
 # promoted packages.  The development key is also used for contrib.
 # The tag parsing logic does not set "$REPO" for contrib repos,
-# instead it puts "contrib" in $SERIES. Same for empty.
-if [[ $REPO == development || $SERIES == *contrib* || $SERIES == *empty* ]]; then
+# instead it puts "contrib" in $SERIES
+if [[ $REPO == development || $SERIES == *contrib* ]]; then
     KEYS=$auto_key
 else
     KEYS=$developer_key

--- a/bin/new_mashfile.sh
+++ b/bin/new_mashfile.sh
@@ -73,10 +73,8 @@ case $SERIES in
 esac
 
 # In OSG 23+, we have a separate signing key for development versus
-# promoted packages.  The development key is also used for contrib.
-# The tag parsing logic does not set "$REPO" for contrib repos,
-# instead it puts "contrib" in $SERIES
-if [[ $REPO == development || $SERIES == *contrib* ]]; then
+# promoted packages.
+if [[ $REPO == development || $REPO == contrib ]]; then
     KEYS=$auto_key
 else
     KEYS=$developer_key


### PR DESCRIPTION
Revert #71, #72, and #73 -- even though not all of the packages in 23-contrib and 23-empty were signed with the 'developer' key, the repo definition files we ship in osg-release say that's the key that should be used.  Instead, the solution to the mash pull failures is to manually sign the packages, which I did with the following:

```
osg-koji -q list-tagged osg-23-el8-empty | awk '{print $1}' | tee packages
xargs -a packages osg-sign OSG-23-developer
osg-koji -q list-tagged osg-23-el9-empty | awk '{print $1}' | tee packages
xargs -a packages osg-sign OSG-23-developer
osg-koji -q list-tagged osg-23-el9-contrib | awk '{print $1}' | tee packages
xargs -a packages osg-sign OSG-23-developer
osg-koji -q list-tagged osg-23-el8-contrib | awk '{print $1}' | tee packages
xargs -a packages osg-sign OSG-23-developer
```