### PR TITLE
EL9 various fixups

### DIFF
--- a/distrepos/__main__.py
+++ b/distrepos/__main__.py
@@ -68,7 +68,8 @@ def create_mirrorlists(options: Options, tags: t.Sequence[Tag]) -> int:
         lock_path = options.lock_dir / "mirrors"
         lock_fh = acquire_lock(lock_path)
         if not lock_fh:
-            return False, f"Could not lock {lock_path}"
+            _log.error(f"Could not lock {lock_path}")
+            return ERR_FAILURES
 
     # Generate mirrors for each tag defined in the config file.  Tags are run in series.
     # Keep track of successes and failures.

--- a/distrepos/__main__.py
+++ b/distrepos/__main__.py
@@ -42,7 +42,6 @@ from datetime import datetime
 from pathlib import Path
 
 _log = logging.getLogger(__name__)
-_log.addHandler(logging.StreamHandler(sys.stdout))
 
 
 #

--- a/distrepos/error.py
+++ b/distrepos/error.py
@@ -10,6 +10,7 @@ ERR_CONFIG = 3
 ERR_RSYNC = 4
 ERR_FAILURES = 5
 ERR_EMPTY = 6
+ERR_DISKFULL = 7
 
 #
 # Error classes
@@ -35,6 +36,17 @@ class RsyncError(ProgramError):
 
     def __str__(self):
         return f"rsync error: {super().__str__()}"
+
+
+class DiskFullError(ProgramError):
+    """
+    Class for the disk being filled up; this is fatal.
+    """
+    def __init__(self, *args):
+        super().__init__(ERR_DISKFULL, *args)
+
+    def __str__(self):
+        return f"disk full: {super().__str__()}"
 
 
 class ConfigError(ProgramError):

--- a/distrepos/params.py
+++ b/distrepos/params.py
@@ -167,17 +167,16 @@ def setup_logging(logfile: t.Optional[str], debug: bool) -> None:
     Sets up logging, given an optional logfile.
 
     Logs are written to a logfile if one is defined. In addition,
-    log to stderr if it's a tty.
+    log to stderr.
     """
     loglevel = logging.DEBUG if debug else logging.INFO
     rootlog = logging.getLogger()
     rootlog.setLevel(loglevel)
-    if sys.stderr.isatty():
-        ch = logging.StreamHandler()
-        ch.setLevel(loglevel)
-        chformatter = logging.Formatter(">>>\t%(message)s")
-        ch.setFormatter(chformatter)
-        rootlog.addHandler(ch)
+    ch = logging.StreamHandler()
+    ch.setLevel(loglevel)
+    chformatter = logging.Formatter("[%(asctime)s]\t%(message)s")
+    ch.setFormatter(chformatter)
+    rootlog.addHandler(ch)
     if logfile:
         rfh = logging.handlers.RotatingFileHandler(
             logfile,

--- a/distrepos/util.py
+++ b/distrepos/util.py
@@ -2,10 +2,12 @@
 Utilities used in distrepos
 """
 
+import errno
 import fcntl
 import fnmatch
 import logging
 import os
+import re
 import subprocess as sp
 import typing as t
 
@@ -296,6 +298,23 @@ def log_rsync(
         success_level=success_level,
         failure_level=failure_level,
         log=log,
+    )
+
+
+def rsync_disk_is_full(proc: sp.CompletedProcess) -> bool:
+    """
+    Check the output of rsync to see if it complained about writing to a
+    full disk.
+
+    Returns:
+        True if rsync failed to a full disk.
+    """
+    return bool(
+        re.search(
+            r"rsync: \[receiver] write failed.*[(]%d[)]$" % errno.ENOSPC,
+            proc.stderr,
+            re.MULTILINE
+        )
     )
 
 


### PR DESCRIPTION
- Fix return in create_mirrorlists()
- Always log to stderr; put timestamp in log message
- Detect and bail out early if the disk gets filled up