### PR TITLE
SOFTWARE-5987: symlink static data

### DIFF
--- a/distrepos/__main__.py
+++ b/distrepos/__main__.py
@@ -221,7 +221,7 @@ def link_static(options: Options) -> int:
             _log.warning(f"Unable to update static-data symlinks: {err}")
             return ERR_FAILURES
     except Exception as e:
-        _log.error(f"Unexpected error updating static-data symlinks: {e}")
+        _log.exception(f"Unexpected error updating static-data symlinks: {e}")
         return ERR_FAILURES
 
 #

--- a/distrepos/__main__.py
+++ b/distrepos/__main__.py
@@ -44,6 +44,7 @@ from distrepos.params import (
 )
 from distrepos.tag_run import run_one_tag
 from distrepos.mirror_run import update_mirrors_for_tag
+from distrepos.link_static import link_static_data
 from distrepos.util import lock_context, check_rsync, log_ml, run_with_log
 
 from datetime import datetime
@@ -205,6 +206,24 @@ def update_repo_timestamp(options: Options):
         f.write(datetime.now().strftime("%a %d %b %Y %H:%M:%S %Z"))
 
 
+def link_static(options: Options) -> int:
+    """
+    Create symlinks from the main data directory to the static data directory
+    """
+
+    _log.info("Updating symlinks to static-data directory")
+    try:
+        ok, err = link_static_data(options)
+        if ok:
+            _log.info("static-data symlinks updated successfully")
+            return 0
+        else:
+            _log.warning(f"Unable to update static-data symlinks: {err}")
+            return ERR_FAILURES
+    except Exception as e:
+        _log.error(f"Unexpected error updating static-data symlinks: {e}")
+        return ERR_FAILURES
+
 #
 # Main function
 #
@@ -258,6 +277,9 @@ def main(argv: t.Optional[t.List[str]] = None) -> int:
 
     if ActionType.MIRROR in args.action and not result:
         result = create_mirrorlists(options, taglist)
+
+    if ActionType.LINK_STATIC in args.action and not result:
+        result = link_static(options)
 
     # If all actions were successful, update the repo timestamp
     if not result:

--- a/distrepos/link_static.py
+++ b/distrepos/link_static.py
@@ -1,0 +1,63 @@
+import typing as t
+from pathlib import Path
+from distrepos.params import Options
+
+
+def link_static_data(options: Options, repo_name: str = "osg") -> t.Tuple[bool, str]:
+    """
+    Utility function to create a symlink to each top-level directory under options.static_root
+    from options.dest_root
+    
+    Args:
+        options: The global options for the run
+        repo_name: The repo to link between dest_root and static_root
+
+    Returns:
+        An (ok, error message) tuple.
+
+    TODO: "osg" repo is essentially hardcoded by the default arg here, might want to specify
+          somewhere in config instead
+    """
+    if not options.static_root:
+        # no static data specified, no op
+        return True, ""
+
+    # This code assumes options.static_root is an absolute path
+    if not Path('/') in options.static_root.parents:
+        return False, f"Static data path must be absolute, got {options.static_root}"
+
+    static_src = options.static_root / repo_name
+    data_dst = options.dest_root / repo_name
+    
+    if not static_src.exists():
+        return False, f"Static data path {static_src} does not exist"
+
+    if not data_dst.exists():
+        # TODO should this be an error instead?
+        data_dst.mkdir(parents=False)
+
+
+    # clear out decayed symlinks to static_src in data_dst
+    for pth in data_dst.iterdir():
+        if pth.is_symlink() and static_src in pth.readlink().parents and not pth.readlink().exists():
+            pth.unlink()
+
+    # create missing symlinks to static_src in data_dist
+    for pth in static_src.iterdir():
+        dest = data_dst / pth.name
+        # Continue if symlink is already correct
+        if dest.is_symlink() and dest.readlink() == pth:
+            continue
+
+        if dest.is_symlink() and dest.readlink() != pth:
+            # Reassign incorrect symlinks
+            dest.unlink()
+        elif dest.exists():
+            # Fail if dest is not a symlink
+            return False, f"Expected static data symlink {dest} is not a symlink"
+
+        # Create the symlink
+        dest.symlink_to(pth)
+    
+    return True, ""
+        

--- a/distrepos/link_static.py
+++ b/distrepos/link_static.py
@@ -33,7 +33,6 @@ def link_static_data(options: Options, repo_name: str = "osg") -> t.Tuple[bool, 
         return False, f"Static data path {static_src} does not exist"
 
     if not data_dst.exists():
-        # TODO should this be an error instead?
         data_dst.mkdir(parents=False)
 
 

--- a/distrepos/params.py
+++ b/distrepos/params.py
@@ -73,7 +73,7 @@ class Options(t.NamedTuple):
     dest_root: Path
     working_root: Path
     previous_root: Path
-    static_root: Path
+    static_root: t.Optional[Path]
     koji_rsync: str
     condor_rsync: str
     lock_dir: t.Optional[Path]

--- a/distrepos/params.py
+++ b/distrepos/params.py
@@ -73,6 +73,7 @@ class Options(t.NamedTuple):
     dest_root: Path
     working_root: Path
     previous_root: Path
+    static_root: Path
     koji_rsync: str
     condor_rsync: str
     lock_dir: t.Optional[Path]
@@ -86,6 +87,7 @@ class ActionType(str, Enum):
     RSYNC = "rsync"
     CADIST = "cadist"
     MIRROR = "mirror"
+    LINK_STATIC = "link_static"
 
 
 def format_tag(
@@ -371,6 +373,9 @@ def get_options(args: Namespace, config: ConfigParser) -> Options:
         dest_root = options_section.get("dest_root", DEFAULT_DESTROOT).rstrip("/")
         working_root = options_section.get("working_root", dest_root + ".working")
         previous_root = options_section.get("previous_root", dest_root + ".previous")
+
+    static_root = options_section.get("static_root", "").rstrip("/")
+
     mirror_root = options_section.get("mirror_root", None)
     mirror_working_root = None if mirror_root is None else mirror_root + '.working'
     mirror_prev_root = None if mirror_root is None else mirror_root + '.prev'
@@ -379,6 +384,7 @@ def get_options(args: Namespace, config: ConfigParser) -> Options:
         dest_root=Path(dest_root),
         working_root=Path(working_root),
         previous_root=Path(previous_root),
+        static_root=Path(static_root) if static_root else None,
         condor_rsync=options_section.get("condor_rsync", DEFAULT_CONDOR_RSYNC),
         koji_rsync=options_section.get("koji_rsync", DEFAULT_KOJI_RSYNC),
         lock_dir=Path(args.lock_dir) if args.lock_dir else None,

--- a/docker/supervisor-distrepos.conf
+++ b/docker/supervisor-distrepos.conf
@@ -1,5 +1,5 @@
 [program:distrepos]
-command=/bin/bash -c "/bin/distrepos --action rsync; /bin/distrepos --action mirror; /bin/distrepos --action cadist; sleep 360"
+command=/bin/bash -c 'for action in link_static rsync mirror cadist; do /bin/distrepos --action $action; done; sleep 360'
 autorestart=true
 
 # Log the output of distrepos to supervisord's stdout/err so k8s logging picks it up

--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -72,7 +72,7 @@ previous_root = /data/repo.previous
 # The location of the log file for the program.
 logfile = /var/log/distrepos.log
 
-# The location of 
+# The location of static repo files not managed by the distrepo script.
 static_root = /static-data/repo
 
 # The base location of mirrorlist files.

--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -72,6 +72,9 @@ previous_root = /data/repo.previous
 # The location of the log file for the program.
 logfile = /var/log/distrepos.log
 
+# The location of 
+static_root = /static-data/repo
+
 # The base location of mirrorlist files.
 mirror_root = /data/mirror
 


### PR DESCRIPTION
- Add a config knob to specify a static repo data directory
- Periodically create symlinks from the "live data" dir to the static dir
  - Attempt to reconcile potential changes in the static dir (which are unlikely to happen)