### PR TITLE
Add config for OSG 24

### DIFF
--- a/distrepos/tag_run.py
+++ b/distrepos/tag_run.py
@@ -111,6 +111,11 @@ def pull_condor_repos(options: Options, tag: Tag):
             source_rpms_dst = sub_arch(
                 f"{working_root}/{tag.source_rpms_dest}/{repo.dst}/"
             )
+            # Make parent directories, for the edge case where the tag itself
+            # is empty in Koji but we have condor RPMs to rsync.
+            os.makedirs(os.path.dirname(arch_rpms_dst), exist_ok=True)
+            os.makedirs(os.path.dirname(debug_rpms_dst), exist_ok=True)
+            os.makedirs(os.path.dirname(source_rpms_dst), exist_ok=True)
 
             arch_rpms_link = sub_arch(f"{dest_root}/{tag.arch_rpms_dest}/{repo.dst}/")
             debug_rpms_link = sub_arch(f"{dest_root}/{tag.debug_rpms_dest}/{repo.dst}/")

--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -47,6 +47,21 @@ daily_repo = 23.0/$${EL}/$${ARCH}/daily -> condor-daily
 update_repo = 23.0/$${EL}/$${ARCH}/update -> condor-update
 release_repo = 23.0/$${EL}/$${ARCH}/release -> condor-release
 
+
+# TODO Condor 24.x does not exist yet so use 23.x
+[condor-24.x]
+daily_repo = 23.x/$${EL}/$${ARCH}/daily -> condor-daily
+update_repo = 23.x/$${EL}/$${ARCH}/update -> condor-update
+release_repo = 23.x/$${EL}/$${ARCH}/release -> condor-release
+
+
+# TODO Condor 24.0 does not exist yet so use 23.x
+[condor-24.0]
+daily_repo = 23.x/$${EL}/$${ARCH}/daily -> condor-daily
+update_repo = 23.x/$${EL}/$${ARCH}/update -> condor-update
+release_repo = 23.x/$${EL}/$${ARCH}/release -> condor-release
+
+
 #
 #
 # Global options
@@ -162,3 +177,69 @@ dest = osg/23-internal/$${EL}/development
 [tagset osg-23-internal-$${EL}-release]
 dvers = el8 el9
 dest = osg/23-internal/$${EL}/release
+
+
+
+#
+# OSG 24 main
+#
+
+[tagset osg-24-main-$${EL}-development]
+dvers = el8 el9
+dest = osg/24-main/$${EL}/development
+condor_repos = ${condor-24.0:daily_repo}
+
+[tagset osg-24-main-$${EL}-testing]
+dvers = el8 el9
+dest = osg/24-main/$${EL}/testing
+condor_repos =
+  ${condor-24.0:release_repo}
+  ${condor-24.0:update_repo}
+
+[tagset osg-24-main-$${EL}-release]
+dvers = el8 el9
+dest = osg/24-main/$${EL}/release
+condor_repos = ${condor-24.0:release_repo}
+
+
+#
+# OSG 24 upcoming
+#
+
+[tagset osg-24-upcoming-$${EL}-development]
+dvers = el8 el9
+dest = osg/24-upcoming/$${EL}/development
+condor_repos = ${condor-24.x:daily_repo}
+
+[tagset osg-24-upcoming-$${EL}-testing]
+dvers = el8 el9
+dest = osg/24-upcoming/$${EL}/testing
+condor_repos =
+  ${condor-24.x:release_repo}
+  ${condor-24.x:update_repo}
+
+[tagset osg-24-upcoming-$${EL}-release]
+dvers = el8 el9
+dest = osg/24-upcoming/$${EL}/release
+condor_repos = ${condor-24.x:release_repo}
+
+
+#
+# OSG 24 contrib, empty, and internal
+#
+
+[tagset osg-24-$${EL}-contrib]
+dvers = el8 el9
+dest = osg/24-contrib/$${EL}
+
+[tagset osg-24-$${EL}-empty]
+dvers = el8 el9
+dest = osg/24-empty/$${EL}
+
+[tagset osg-24-internal-$${EL}-development]
+dvers = el8 el9
+dest = osg/24-internal/$${EL}/development
+
+[tagset osg-24-internal-$${EL}-release]
+dvers = el8 el9
+dest = osg/24-internal/$${EL}/release


### PR DESCRIPTION
Since HTCondor 24.x and 24.0 aren't out yet, use the 23.x repos in the definitions.

Also I had to make a change to create a tag's directories before rsyncing condor RPMs into them -- this is because the 24-upcoming-release and -testing tags are empty right now, so those directories don't exist.