### PR TITLE
Do not add condor repos to OSG 24 for now

### DIFF
--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -48,18 +48,16 @@ update_repo = 23.0/$${EL}/$${ARCH}/update -> condor-update
 release_repo = 23.0/$${EL}/$${ARCH}/release -> condor-release
 
 
-# TODO Condor 24.x does not exist yet so use 23.x
 [condor-24.x]
-daily_repo = 23.x/$${EL}/$${ARCH}/daily -> condor-daily
-update_repo = 23.x/$${EL}/$${ARCH}/update -> condor-update
-release_repo = 23.x/$${EL}/$${ARCH}/release -> condor-release
+daily_repo = 24.x/$${EL}/$${ARCH}/daily -> condor-daily
+update_repo = 24.x/$${EL}/$${ARCH}/update -> condor-update
+release_repo = 24.x/$${EL}/$${ARCH}/release -> condor-release
 
 
-# TODO Condor 24.0 does not exist yet so use 23.x
 [condor-24.0]
-daily_repo = 23.x/$${EL}/$${ARCH}/daily -> condor-daily
-update_repo = 23.x/$${EL}/$${ARCH}/update -> condor-update
-release_repo = 23.x/$${EL}/$${ARCH}/release -> condor-release
+daily_repo = 24.0/$${EL}/$${ARCH}/daily -> condor-daily
+update_repo = 24.0/$${EL}/$${ARCH}/update -> condor-update
+release_repo = 24.0/$${EL}/$${ARCH}/release -> condor-release
 
 
 #
@@ -187,19 +185,19 @@ dest = osg/23-internal/$${EL}/release
 [tagset osg-24-main-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-main/$${EL}/development
-condor_repos = ${condor-24.0:daily_repo}
+# condor_repos = ${condor-24.0:daily_repo}
 
 [tagset osg-24-main-$${EL}-testing]
 dvers = el8 el9
 dest = osg/24-main/$${EL}/testing
-condor_repos =
-  ${condor-24.0:release_repo}
-  ${condor-24.0:update_repo}
+# condor_repos =
+#   ${condor-24.0:release_repo}
+#   ${condor-24.0:update_repo}
 
 [tagset osg-24-main-$${EL}-release]
 dvers = el8 el9
 dest = osg/24-main/$${EL}/release
-condor_repos = ${condor-24.0:release_repo}
+# condor_repos = ${condor-24.0:release_repo}
 
 
 #
@@ -209,19 +207,19 @@ condor_repos = ${condor-24.0:release_repo}
 [tagset osg-24-upcoming-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/development
-condor_repos = ${condor-24.x:daily_repo}
+# condor_repos = ${condor-24.x:daily_repo}
 
 [tagset osg-24-upcoming-$${EL}-testing]
 dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/testing
-condor_repos =
-  ${condor-24.x:release_repo}
-  ${condor-24.x:update_repo}
+# condor_repos =
+#   ${condor-24.x:release_repo}
+#   ${condor-24.x:update_repo}
 
 [tagset osg-24-upcoming-$${EL}-release]
 dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/release
-condor_repos = ${condor-24.x:release_repo}
+# condor_repos = ${condor-24.x:release_repo}
 
 
 #


### PR DESCRIPTION
We can't use the 23.x repos to get condor from for now, because the RPMs
in the 23.x repos are not signed with the OSG 24 key.
