### PR TITLE
Don't try to pull from Condor 24 repos: it hasn't been released yet

### DIFF
--- a/bin/pull_condor_rpms.sh
+++ b/bin/pull_condor_rpms.sh
@@ -53,6 +53,10 @@ case $TAG in
   * ) usage ;;
 esac
 
+if [[ $SERIES == 24 ]]; then
+    tag_not_supported  # Condor 24 isn't released yet
+fi
+
 # branch "upcoming" corresponds to SERIES.x in htcondor, "main" corresponds to SERIES.0
 # others do not have a corresponding series
 case $BRANCH in


### PR DESCRIPTION
This is for the old repo image; we need the OSG repos to exist so we can get some testing done.