### PR TITLE
Deal with htcondor repo renames for 24.0 and 24.x

### DIFF
--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -49,14 +49,14 @@ release_repo = 23.0/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-24.x]
-daily_repo = 24.x/$${EL}/$${ARCH}/daily -> condor-daily
-update_repo = 24.x/$${EL}/$${ARCH}/update -> condor-update
+snapshot_repo = 24.x/$${EL}/$${ARCH}/snapshot -> condor-snapshot
+beta_repo = 24.x/$${EL}/$${ARCH}/beta -> condor-beta
 release_repo = 24.x/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-24.0]
-daily_repo = 24.0/$${EL}/$${ARCH}/daily -> condor-daily
-update_repo = 24.0/$${EL}/$${ARCH}/update -> condor-update
+snapshot_repo = 24.0/$${EL}/$${ARCH}/snapshot -> condor-snapshot
+beta_repo = 24.0/$${EL}/$${ARCH}/beta -> condor-beta
 release_repo = 24.0/$${EL}/$${ARCH}/release -> condor-release
 
 
@@ -204,14 +204,14 @@ dest = osg/23-internal/$${EL}/release
 [tagset osg-24-main-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-main/$${EL}/development
-condor_repos = ${condor-24.0:daily_repo}
+condor_repos = ${condor-24.0:snapshot_repo}
 
 [tagset osg-24-main-$${EL}-testing]
 dvers = el8 el9
 dest = osg/24-main/$${EL}/testing
 condor_repos =
   ${condor-24.0:release_repo}
-  ${condor-24.0:update_repo}
+  ${condor-24.0:beta_repo}
 
 [tagset osg-24-main-$${EL}-release]
 dvers = el8 el9
@@ -226,14 +226,14 @@ condor_repos = ${condor-24.0:release_repo}
 [tagset osg-24-upcoming-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/development
-condor_repos = ${condor-24.x:daily_repo}
+condor_repos = ${condor-24.x:snapshot_repo}
 
 [tagset osg-24-upcoming-$${EL}-testing]
 dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/testing
 condor_repos =
   ${condor-24.x:release_repo}
-  ${condor-24.x:update_repo}
+  ${condor-24.x:beta_repo}
 
 [tagset osg-24-upcoming-$${EL}-release]
 dvers = el8 el9


### PR DESCRIPTION
"daily" got renamed to "snapshot"
"update" got renamed to "beta"

el8 and el9 have compat symlinks, but el10 doesn't