### PR TITLE
SOFTWARE-6175: el10 support

### DIFF
--- a/distrepos/params.py
+++ b/distrepos/params.py
@@ -95,7 +95,7 @@ class Options(t.NamedTuple):
     mirror_prev_root: t.Optional[Path]
     mirror_hosts: t.List[str]
     tarball_install: str
-    arch_mappings: t.Dict[str, t.List[str]]
+    arch_mappings: t.Dict[str, str]
 
 
 class ActionType(str, Enum):

--- a/distrepos/params.py
+++ b/distrepos/params.py
@@ -95,6 +95,7 @@ class Options(t.NamedTuple):
     mirror_prev_root: t.Optional[Path]
     mirror_hosts: t.List[str]
     tarball_install: str
+    arch_mappings: t.Dict[str, t.List[str]]
 
 
 class ActionType(str, Enum):
@@ -423,6 +424,15 @@ def get_options(args: Namespace, config: ConfigParser) -> Options:
     mirror_working_root = None if mirror_root is None else mirror_root + '.working'
     mirror_prev_root = None if mirror_root is None else mirror_root + '.prev'
     mirror_hosts = options_section.get("mirror_hosts", "").split()
+    
+    # Convert "arch1 -> arch2" multiline string into {"arch1":"arch2"} dict
+    arch_mappings = {
+        k.strip(): v.strip() for k,v in 
+        (kv for kv in ( 
+            line.split("->",1) for line in options_section.get("arch_mappings", "").split('\n')
+        ) if len(kv) == 2)
+    }
+
     options = Options(
         dest_root=Path(dest_root),
         working_root=Path(working_root),
@@ -436,7 +446,8 @@ def get_options(args: Namespace, config: ConfigParser) -> Options:
         mirror_working_root=mirror_working_root,
         mirror_prev_root=mirror_prev_root,
         mirror_hosts=mirror_hosts,
-        tarball_install=options_section.get("tarball_install", DEFAULT_TARBALL_INSTALL_DIR)
+        tarball_install=options_section.get("tarball_install", DEFAULT_TARBALL_INSTALL_DIR),
+        arch_mappings=arch_mappings
     )
     return options
 

--- a/distrepos/tag_run.py
+++ b/distrepos/tag_run.py
@@ -16,7 +16,6 @@ import re
 
 from distrepos.error import DiskFullError, TagFailure
 from distrepos.params import Options, Tag, ReleaseSeries
-from distrepos.symlink_utils import link_arch_mapping
 from distrepos.util import (
     RSYNC_NOT_FOUND,
     RSYNC_OK,

--- a/distrepos/tag_run.py
+++ b/distrepos/tag_run.py
@@ -322,6 +322,7 @@ def create_arches_symlinks(options: Options, working_path: Path, arches: t.List[
     in `options.arch_mapping`. Ensures compatibility between systems with different
     names for similar arches (eg. x86_64_v2 in koji and x86_64 on some destination hosts)
     """
+    _log.debug(f"_create_arches_symlink({options.arch_mappings}, {working_path}, {arches})")
     for arch in arches:
         if not arch in options.arch_mappings:
             continue
@@ -330,6 +331,7 @@ def create_arches_symlinks(options: Options, working_path: Path, arches: t.List[
             os.symlink(link_dir, f"./{arch}")
         except OSError as err:
             raise TagFailure(f"Unable to symlink arch {arch}") from err
+    _log.info("creating arches symlink ok")
 
 def create_compat_symlink(working_path: Path):
     """

--- a/distrepos/tag_run.py
+++ b/distrepos/tag_run.py
@@ -328,7 +328,7 @@ def create_arches_symlinks(options: Options, working_path: Path, arches: t.List[
             continue
         try:
             link_dir = working_path / options.arch_mappings[arch]
-            os.symlink(link_dir, f"./{arch}")
+            os.symlink(f"./{arch}", link_dir)
         except OSError as err:
             raise TagFailure(f"Unable to symlink arch {arch}") from err
     _log.info("creating arches symlink ok")

--- a/distrepos/tag_run.py
+++ b/distrepos/tag_run.py
@@ -16,6 +16,7 @@ import re
 
 from distrepos.error import DiskFullError, TagFailure
 from distrepos.params import Options, Tag, ReleaseSeries
+from distrepos.symlink_utils import link_arch_mapping
 from distrepos.util import (
     RSYNC_NOT_FOUND,
     RSYNC_OK,
@@ -316,6 +317,20 @@ def run_createrepo(working_path: Path, arches: t.List[str]):
         else:
             raise TagFailure(f"Error {description}")
 
+def create_arches_symlinks(options: Options, working_path: Path, arches: t.List[str]):
+    """
+    Create relative symlinks from dest_arch to src_arc based on config provided
+    in `options.arch_mapping`. Ensures compatibility between systems with different
+    names for similar arches (eg. x86_64_v2 in koji and x86_64 on some destination hosts)
+    """
+    for arch in arches:
+        if not arch in options.arch_mappings:
+            continue
+        try:
+            link_dir = working_path / options.arch_mappings[arch]
+            os.symlink(link_dir, f"./{arch}")
+        except OSError as err:
+            raise TagFailure(f"Unable to symlink arch {arch}") from err
 
 def create_compat_symlink(working_path: Path):
     """
@@ -453,6 +468,7 @@ def run_one_tag(options: Options, tag: Tag) -> t.Tuple[bool, str]:
         update_pkglist_files(working_path, tag.arches)
         run_createrepo(working_path, tag.arches)
         create_compat_symlink(working_path)
+        create_arches_symlinks(options, working_path, tag.arches)
         update_release_repos(
             release_path=release_path,
             working_path=working_path,

--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -104,6 +104,11 @@ mirror_hosts =
 # Parent directory within dest_root for tarball client
 tarball_install = tarball-install
 
+# Support for symlinking an arch name as it appears in koji (eg. x86_64_v2)
+# to the arch name as it might appear on a host (eg. x86_64)
+arch_mappings =
+    x86_64_v2 -> x86_64
+
 #
 # Release series
 #
@@ -218,6 +223,12 @@ dvers = el8 el9
 dest = osg/24-main/$${EL}/release
 condor_repos = ${condor-24.0:release_repo}
 
+# EL10 support
+[tag osg-24-main-el10-development]
+arches = x86_64_v2 aarch64
+dvers = el10
+dest = osg/24-main/el10/development
+condor_repos = 24.x/el10/$${ARCH}/snapshot -> condor-snapshot
 
 #
 # OSG 24 upcoming

--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -228,7 +228,21 @@ condor_repos = ${condor-24.0:release_repo}
 arches = x86_64_v2 aarch64
 dvers = el10
 dest = osg/24-main/el10/development
-condor_repos = 24.x/el10/$${ARCH}/snapshot -> condor-snapshot
+condor_repos = 24.0/el10/$${ARCH}/snapshot -> condor-snapshot
+
+[tag osg-24-main-el10-testing]
+arches = x86_64_v2 aarch64
+dvers = el10
+dest = osg/24-main/el10/testing
+condor_repos = 
+    24.0/el10/$${ARCH}/beta -> condor-beta
+    24.0/el10/$${ARCH}/release -> condor-release
+
+[tag osg-24-main-el10-release]
+arches = x86_64_v2 aarch64
+dvers = el10
+dest = osg/24-main/el10/release
+condor_repos = 24.0/$${EL}/$${ARCH}/release -> condor-release
 
 #
 # OSG 24 upcoming
@@ -251,6 +265,27 @@ dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/release
 condor_repos = ${condor-24.x:release_repo}
 
+# EL10 support
+[tag osg-24-upcoming-el10-development]
+arches = x86_64_v2 aarch64
+dvers = el10
+dest = osg/24-upcoming/el10/development
+condor_repos = 24.x/el10/$${ARCH}/snapshot -> condor-snapshot
+
+[tag osg-24-upcoming-el10-testing]
+arches = x86_64_v2 aarch64
+dvers = el10
+dest = osg/24-upcoming/el10/testing
+condor_repos = 
+    24.x/el10/$${ARCH}/beta -> condor-beta
+    24.x/el10/$${ARCH}/release -> condor-release
+
+[tag osg-24-upcoming-el10-release]
+arches = x86_64_v2 aarch64
+dvers = el10
+dest = osg/24-upcoming/el10/release
+condor_repos = 24.x/el10/$${ARCH}/release -> condor-release
+
 
 #
 # OSG 24 contrib, empty, and internal
@@ -271,3 +306,24 @@ dest = osg/24-internal/$${EL}/development
 [tagset osg-24-internal-$${EL}-release]
 dvers = el8 el9
 dest = osg/24-internal/$${EL}/release
+
+# EL10 support
+[tag osg-24-el10-contrib]
+arches = x86_64_v2 aarch64
+dvers = el8 el9
+dest = osg/24-contrib/el10
+
+[tag osg-24-el10-empty]
+arches = x86_64_v2 aarch64
+dvers = el8 el9
+dest = osg/24-empty/el10
+
+[tag osg-24-internal-el10-development]
+arches = x86_64_v2 aarch64
+dvers = el8 el9
+dest = osg/24-internal/el10/development
+
+[tag osg-24-internal-el10-release]
+arches = x86_64_v2 aarch64
+dvers = el8 el9
+dest = osg/24-internal/el10/release


### PR DESCRIPTION
- Add various el10 tags for osg24 as individual tags using the x86_64_v2 arch (as opposed to updating the existing tagsets)
- Add new `arch_mappings` config section that specifies which arches should be symlinked to each other (in this case x86_64 to x86_64_V2)