### PR TITLE
Run multiple tags in parallel

### DIFF
--- a/distrepos/__main__.py
+++ b/distrepos/__main__.py
@@ -171,10 +171,11 @@ def rsync_repos(options: Options, tags: t.Sequence[Tag]) -> int:
 
 def _run_one_tag_wrapper(options: Options, tag: Tag) -> t.Optional[str]:
     """
+    A wrapper around run_one_tag(), timing it and returning the results.
 
     Args:
-        options:
-        tag:
+        options: The global Options object.
+        tag: The specific tag to run.
 
     Returns:
         None on success, an error string on failure

--- a/distrepos/__main__.py
+++ b/distrepos/__main__.py
@@ -47,7 +47,7 @@ from distrepos.params import (
 from distrepos.tag_run import run_one_tag
 from distrepos.mirror_run import update_mirrors_for_tag
 from distrepos.symlink_utils import link_static_data, link_latest_release
-from distrepos.util import lock_context, check_rsync, log_ml, run_with_log
+from distrepos.util import TagLogger, lock_context, check_rsync, log_ml, run_with_log
 from distrepos.tarball_sync import update_tarball_dirs
 
 from datetime import datetime
@@ -180,7 +180,8 @@ def _run_one_tag_wrapper(options: Options, tag: Tag) -> t.Optional[str]:
         None on success, an error string on failure
     """
     # _log.info("----------------------------------------")
-    _log.info("%s: Starting tag", tag.name)
+    log = TagLogger(_log, {"tag": tag.name})
+    log.info("Starting tag")
     log_ml(
         logging.DEBUG,
         "%s",
@@ -190,16 +191,16 @@ def _run_one_tag_wrapper(options: Options, tag: Tag) -> t.Optional[str]:
             condor_rsync=options.condor_rsync,
             destroot=options.dest_root,
         ),
-        prefix=f"{tag.name}: ",
+        log=log,
     )
     tag_start_time = datetime.now()
     ok, err = run_one_tag(options, tag)
     tag_elapsed_time = datetime.now() - tag_start_time
     if ok:
-        _log.info("%s: Tag completed in %s", tag.name, tag_elapsed_time)
+        log.info("Tag completed in %s", tag_elapsed_time)
         return None
     else:
-        _log.error("%s: Tag failed in %s", tag.name, tag_elapsed_time)
+        log.error("Tag failed in %s", tag_elapsed_time)
         return err
 
 

--- a/distrepos/__main__.py
+++ b/distrepos/__main__.py
@@ -26,6 +26,7 @@ repo -- this is passed to `createrepo` to put the debuginfo and debugsource RPMs
 separate repositories even though the files are mixed together.
 """
 
+import concurrent.futures
 import logging
 import sys
 import typing as t
@@ -133,28 +134,15 @@ def rsync_repos(options: Options, tags: t.Sequence[Tag]) -> int:
     # Keep track of successes and failures.
     successful = []
     failed = []
-    for tag in tags:
-        _log.info("----------------------------------------")
-        _log.info("Starting tag %s", tag.name)
-        log_ml(
-            logging.DEBUG,
-            "%s",
-            format_tag(
-                tag,
-                koji_rsync=options.koji_rsync,
-                condor_rsync=options.condor_rsync,
-                destroot=options.dest_root,
-            ),
-        )
-        tag_start_time = datetime.now()
-        ok, err = run_one_tag(options, tag)
-        tag_elapsed_time = datetime.now() - tag_start_time
-        if ok:
-            _log.info("Tag %s completed in %s", tag.name, tag_elapsed_time)
-            successful.append(tag)
-        else:
-            _log.error("Tag %s failed in %s", tag.name, tag_elapsed_time)
-            failed.append((tag, err))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=options.parallelism) as executor:
+        future_to_tag = {executor.submit(_run_one_tag_wrapper, options, tag): tag for tag in tags}
+        for future in concurrent.futures.as_completed(future_to_tag):
+            tag = future_to_tag[future]
+            err = future.result()
+            if err:
+                failed.append((tag, err))
+            else:
+                successful.append(tag)
 
     total_elapsed_time = datetime.now() - total_start_time
     _log.info("----------------------------------------")
@@ -179,6 +167,41 @@ def rsync_repos(options: Options, tags: t.Sequence[Tag]) -> int:
         return ERR_EMPTY
 
     return 0
+
+
+def _run_one_tag_wrapper(options: Options, tag: Tag) -> t.Optional[str]:
+    """
+
+    Args:
+        options:
+        tag:
+
+    Returns:
+        None on success, an error string on failure
+    """
+    # _log.info("----------------------------------------")
+    _log.info("%s: Starting tag", tag.name)
+    log_ml(
+        logging.DEBUG,
+        "%s",
+        format_tag(
+            tag,
+            koji_rsync=options.koji_rsync,
+            condor_rsync=options.condor_rsync,
+            destroot=options.dest_root,
+        ),
+        prefix=f"{tag.name}: ",
+    )
+    tag_start_time = datetime.now()
+    ok, err = run_one_tag(options, tag)
+    tag_elapsed_time = datetime.now() - tag_start_time
+    if ok:
+        _log.info("%s: Tag completed in %s", tag.name, tag_elapsed_time)
+        return None
+    else:
+        _log.error("%s: Tag failed in %s", tag.name, tag_elapsed_time)
+        return err
+
 
 def update_cadist(options: Options) -> int:
     """

--- a/distrepos/params.py
+++ b/distrepos/params.py
@@ -28,6 +28,7 @@ DEFAULT_DESTROOT = "/data/repo"
 DEFAULT_KOJI_RSYNC = "rsync://kojihub2000.chtc.wisc.edu/repos-dist"
 DEFAULT_TARBALL_RSYNC = "rsync://rsync.cs.wisc.edu/vdt/"
 DEFAULT_LOCK_DIR = "/var/lock/rsync_dist_repo"
+DEFAULT_PARALLELISM = 1
 
 DEFAULT_TARBALL_INSTALL_DIR = 'tarball-install'
 
@@ -96,6 +97,7 @@ class Options(t.NamedTuple):
     mirror_hosts: t.List[str]
     tarball_install: str
     arch_mappings: t.Dict[str, str]
+    parallelism: int
 
 
 class ActionType(str, Enum):
@@ -424,6 +426,13 @@ def get_options(args: Namespace, config: ConfigParser) -> Options:
     mirror_working_root = None if mirror_root is None else mirror_root + '.working'
     mirror_prev_root = None if mirror_root is None else mirror_root + '.prev'
     mirror_hosts = options_section.get("mirror_hosts", "").split()
+
+    try:
+        parallelism = options_section.getint("parallelism", None) or DEFAULT_PARALLELISM
+        if parallelism < 1:
+            raise ValueError("Cannot be zero or negative")
+    except ValueError as err:
+        raise ConfigError("Invalid parallelism: %s" % err)
     
     # Convert "arch1 -> arch2" multiline string into {"arch1":"arch2"} dict
     arch_mappings = {
@@ -447,7 +456,8 @@ def get_options(args: Namespace, config: ConfigParser) -> Options:
         mirror_prev_root=mirror_prev_root,
         mirror_hosts=mirror_hosts,
         tarball_install=options_section.get("tarball_install", DEFAULT_TARBALL_INSTALL_DIR),
-        arch_mappings=arch_mappings
+        arch_mappings=arch_mappings,
+        parallelism=parallelism,
     )
     return options
 

--- a/distrepos/params.py
+++ b/distrepos/params.py
@@ -9,7 +9,6 @@ import logging.handlers
 import os
 import re
 import string
-import sys
 import typing as t
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from configparser import ConfigParser

--- a/distrepos/util.py
+++ b/distrepos/util.py
@@ -383,7 +383,18 @@ def check_rsync(koji_rsync: str, log: MaybeLogger = None) -> None:
 
 
 class TagLogger(logging.LoggerAdapter):
+    """
+    This is a LoggerAdapter used to prefix the tag to log messages.
+    A LoggingAdapter wraps around an existing Logger instance and can be
+    used instead of it.  See
+    <https://docs.python.org/3/howto/logging-cookbook.html#using-loggeradapters-to-impart-contextual-information>
+    for more information.
+    """
+
     def process(self, msg, kwargs):
+        """
+        Prefix the log message with the tag, if applicable.
+        """
         tag = self.extra.get("tag", "")
         if tag and isinstance(tag, str):
             return "[%s] %s" % (tag, msg), kwargs

--- a/distrepos/util.py
+++ b/distrepos/util.py
@@ -101,7 +101,10 @@ def release_lock(lock_fh: t.Optional[t.IO], lock_path: t.Optional[str]):
 #
 
 
-def log_ml(lvl: int, msg: str, *args, log: t.Optional[logging.Logger] = None, **kwargs):
+MaybeLogger = t.Union[None, logging.Logger, logging.LoggerAdapter]
+
+
+def log_ml(lvl: int, msg: str, *args, log: MaybeLogger = None, **kwargs):
     """
     Log a potentially multi-line message by splitting the lines and doing
     individual calls to log.log().  exc_info and stack_info will only be
@@ -146,7 +149,7 @@ def log_proc(
     failure_level=logging.ERROR,
     stdout_max_lines=24,
     stderr_max_lines=40,
-    log: t.Optional[logging.Logger] = None,
+    log: MaybeLogger = None,
 ) -> None:
     """
     Print the result of a process in the log; the loglevel is determined by
@@ -202,7 +205,7 @@ def run_with_log(
     failure_level=logging.ERROR,
     stdout_max_lines=24,
     stderr_max_lines=40,
-    log: t.Optional[logging.Logger] = None,
+    log: MaybeLogger = None,
     **kwargs,
 ) -> t.Tuple[bool, sp.CompletedProcess]:
     """
@@ -242,7 +245,7 @@ def run_with_log(
 
 
 def rsync(
-    *args, log: t.Optional[logging.Logger] = None, **kwargs
+    *args, log: MaybeLogger = None, **kwargs
 ) -> t.Tuple[bool, sp.CompletedProcess]:
     """
     A wrapper around `subprocess.run` that runs rsync, capturing the output
@@ -271,7 +274,7 @@ def rsync_with_link(
     recursive=True,
     delete=True,
     links=False,
-    log: t.Optional[logging.Logger] = None,
+    log: MaybeLogger = None,
 ) -> t.Tuple[bool, sp.CompletedProcess]:
     """
     rsync from a remote URL sourcepath to the destination destpath, optionally
@@ -307,7 +310,7 @@ def log_rsync(
     success_level=logging.DEBUG,
     failure_level=logging.ERROR,
     not_found_is_ok=False,
-    log: t.Optional[logging.Logger] = None,
+    log: MaybeLogger = None,
 ):
     """
     log the result of an rsync() call.  The log level and message are based on
@@ -356,7 +359,7 @@ def match_globlist(text: str, globlist: t.List[str]) -> bool:
     return any(fnmatch.fnmatch(text, g) for g in globlist)
 
 
-def check_rsync(koji_rsync: str, log: t.Optional[logging.Logger] = None) -> None:
+def check_rsync(koji_rsync: str, log: MaybeLogger = None) -> None:
     """
     Run an rsync listing of the rsync root. If this fails, there is no point
     in proceeding further.
@@ -377,3 +380,12 @@ def check_rsync(koji_rsync: str, log: t.Optional[logging.Logger] = None) -> None
     )
     if not ok:
         raise RsyncError("rsync dir listing from koji-hub failed, cannot continue")
+
+
+class TagLogger(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        tag = self.extra.get("tag", "")
+        if tag and isinstance(tag, str):
+            return "[%s] %s" % (tag, msg), kwargs
+        else:
+            return msg, kwargs

--- a/docker/supervisor-distrepos.conf
+++ b/docker/supervisor-distrepos.conf
@@ -1,5 +1,5 @@
 [program:distrepos]
-command=/bin/bash -c 'for action in rsync mirror cadist tarball_sync link_release; do /bin/distrepos --action $action; done; sleep 360'
+command=/bin/bash -c 'for action in rsync mirror cadist tarball_sync link_release; do /bin/distrepos ${DEBUG:+--debug} --action $action; done; sleep 360'
 autorestart=true
 
 # Log the output of distrepos to supervisord's stdout/err so k8s logging picks it up

--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -109,6 +109,9 @@ tarball_install = tarball-install
 arch_mappings =
     x86_64_v2 -> x86_64
 
+# The number of tag pulls to run in parallel
+parallelism = 3
+
 #
 # Release series
 #


### PR DESCRIPTION
This uses [concurrent.futures.ThreadPoolExecutor](https://docs.python.org/3.9/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) to run multiple tags in parallel.  The number of tags to run is configurable in the options; I set it to 3, which drops the cycle time from ~1:40 to ~0:45 (which is about what we were seeing before we added all the el10 tags).

More workers give additional performance gain -- with 6 I could get it down to ~0:25 -- but I consider this just something to tide us over until we can get in the real fix (which is to not run createrepo if it's not necessary).

Most of the lines of code are actually changes to the logging code to prefix each log message with the tag that it applies to.