### PR TITLE
Create and check a 'last-updated' file for up-to-dateness of mirrors,…

### DIFF
--- a/distrepos/mirror_run.py
+++ b/distrepos/mirror_run.py
@@ -42,44 +42,20 @@ def get_mirror_info_for_arch(hostname: str, tag: Tag, arch: str) -> t.Tuple[str,
     # TODO this might be a misuse of os.path.join. The more appropriate function,
     # urllib.parse.urljoin, is very sensitive to leading/trailing slashes in the path parts though
     mirror_base = os.path.join(hostname, path_arch)
-    repomd_url = os.path.join(mirror_base, 'repodata/repomd.xml')
-    return mirror_base, repomd_url
+    last_updated_url = os.path.join(mirror_base, 'last-updated')
+    return mirror_base, last_updated_url
 
 
-def is_migrated(repomd_url: str) -> bool:
+def test_single_mirror(last_updated_url: str) -> bool:
     """
-    Given the URL of a repomd file, check if the repo that owns that file
-    has been migrated to the distrepos format.  This is true if they have
-    a file named "pkglist" as a sibling of the "repodata" folder (which is
-    the parent of the "repomd.xml" file.
-
-    Args:
-        repomd_url: The URL of a repomd.xml file
-
-    Returns: True if the repo is in the distrepos format.
-    """
-    pkglist_url = os.path.dirname(os.path.dirname(repomd_url)) + "/pkglist"
-    _log.info(f"Checking for mirror format based on {pkglist_url}")
-    response = requests.get(pkglist_url, timeout=10)
-    if response.status_code == 404:
-        _log.info(f"pkglist file not found; repo probably not migrated")
-        return False
-    elif response.status_code != 200:
-        _log.warning(f"unexpected response.code for pkglist file {pkglist_url}: {response.status_code}")
-        return False
-    return True
-
-
-def test_single_mirror(repodata_url: str) -> bool:
-    """
-    Given the full URL of a repodata/repomd.xml that might mirror a tag, return whether
+    Given the full URL of a 'last-updated' file in a mirror,
     that file exists and was updated in the past 24 hours.
     """
-    _log.info(f"Checking for existence and up-to-dateness of {repodata_url}")
-    response = requests.get(repodata_url, timeout=10)
+    _log.info(f"Checking for existence and up-to-dateness of {last_updated_url}")
+    response = requests.get(last_updated_url, timeout=10)
     if response.status_code != 200:
         _log.warning(
-            f"bad(non 200) response.code for mirror {repodata_url}: {response.status_code}"
+            f"bad(non 200) response.code for mirror {last_updated_url}: {response.status_code}"
         )
         return False
     else:
@@ -87,7 +63,7 @@ def test_single_mirror(repodata_url: str) -> bool:
         lastmod_str = response.headers.get("Last-Modified")
         if not lastmod_str:
             _log.warning(
-                f"Mirror {repodata_url} missing expected 'Last-Modified' header"
+                f"Mirror {last_updated_url} missing expected 'Last-Modified' header"
             )
             return False
         lastmodtime = datetime.strptime(
@@ -96,16 +72,10 @@ def test_single_mirror(repodata_url: str) -> bool:
         age = datetime.now() - lastmodtime
         if datetime.now() - lastmodtime > timedelta(hours=24):
             _log.warning(
-                f"Mirror {repodata_url} too old ({age} seconds old) Last-Modified: {lastmod_str} ... ignoring"
+                f"Mirror {last_updated_url} too old ({age} seconds old) Last-Modified: {lastmod_str} ... ignoring"
             )
             return False
-        else:
-            if is_migrated(repodata_url):
-                _log.debug(f"Mirror {repodata_url} all good")
-                return True
-            else:
-                _log.debug(f"Mirror {repodata_url} not migrated")
-                return False
+        return True
 
 
 def update_mirrors_for_tag(options: Options, tag: Tag) -> t.Tuple[bool, str]:
@@ -131,8 +101,8 @@ def update_mirrors_for_tag(options: Options, tag: Tag) -> t.Tuple[bool, str]:
         good_mirrors = []
         for hostname in mirror_hostnames:
             _log.info(f"Checking mirror {hostname}")
-            mirror_base, repodata_url = get_mirror_info_for_arch(hostname, tag, arch)
-            if test_single_mirror(repodata_url):
+            mirror_base, last_updated_url = get_mirror_info_for_arch(hostname, tag, arch)
+            if test_single_mirror(last_updated_url=last_updated_url):
                 good_mirrors.append(mirror_base)
 
         # TODO is it a failure if no mirrors are found outside of osg-hosted repos? Assume no

--- a/distrepos/tag_run.py
+++ b/distrepos/tag_run.py
@@ -514,6 +514,53 @@ def update_release_repos(
     log.info("Successfully released %s", release_path)
 
 
+def update_sentinels(release_path: Path, arches: list[str], log: MaybeLogger = None) -> bool:
+    """
+    Update the 'last-updated' files in each repo to show when we last checked
+    for an update; this file is used to see if mirrors are up to date.
+
+    Args:
+        release_path: The 'live' repo
+        arches: The list of architectures in the repo
+        log (optional): A logger
+
+    Returns: True if all sentinels were updated, False otherwise.
+    """
+    log = log or _module_logger
+    log.debug("update_sentinel(%r, %r, %r)", release_path, arches)
+
+    all_ok = True
+    # Check src dir
+
+    src_sentinel = release_path / "src" / "last-updated"
+    try:
+        src_sentinel.touch(exist_ok=True)
+    except OSError as err:
+        log.warning("Could not update %s: %s", src_sentinel, err)
+        all_ok = False
+
+    # arch-specific repos and debug repos
+    for arch in arches:
+        release_arch_sentinel = release_path / arch / "last-updated"
+        try:
+            release_arch_sentinel.touch(exist_ok=True)
+        except OSError as err:
+            log.warning("Could not update %s: %s", release_arch_sentinel, err)
+            all_ok = False
+
+        release_arch_debug_dir = release_path / arch / "debug"
+        if not release_arch_debug_dir.exists():
+            continue
+        release_arch_debug_sentinel = release_arch_debug_dir / "last-updated"
+        try:
+            release_arch_debug_sentinel.touch(exist_ok=True)
+        except OSError as err:
+            log.warning("Could not update %s: %s", release_arch_debug_sentinel, err)
+            all_ok = False
+
+    return all_ok
+
+
 def run_one_tag(options: Options, tag: Tag) -> t.Tuple[bool, str]:
     """
     Run all the actions necessary to create a repo for one tag in the config.
@@ -560,6 +607,7 @@ def run_one_tag(options: Options, tag: Tag) -> t.Tuple[bool, str]:
         update_pkglist_files(working_path, tag.arches, log=log)
         if same_pkglist_files(working_path, release_path, tag.arches, log=log):
             log.info("pkglist files are identical for tag %s, skipping.", tag.name)
+            update_sentinels(release_path, tag.arches, log=log)
             return True, "skipped"
         run_createrepo(working_path, tag.arches, log=log)
         create_compat_symlink(working_path, log=log)
@@ -570,6 +618,8 @@ def run_one_tag(options: Options, tag: Tag) -> t.Tuple[bool, str]:
             previous_path=previous_path,
             log=log,
         )
+        update_sentinels(release_path, tag.arches, log=log)
+        return True, ""
     except TagFailure as err:
         log.error("Tag %s failed: %s", tag.name, err)
         log.debug("Traceback follows", exc_info=True)
@@ -581,4 +631,3 @@ def run_one_tag(options: Options, tag: Tag) -> t.Tuple[bool, str]:
                 release_lock(lock_fh, lock_path)
             except OSError as err:
                 log.warning("OSError releasing lock file at %s: %s", lock_path, err)
-    return True, ""


### PR DESCRIPTION
… as opposed to 'repomd.xml' which may not get updated if the repo doesn't have any new RPMs

The recent change to skip running createrepo if the packages haven't changed between runs causes mirror file generation to fail.  This is because the test for whether a mirror is up to date is based on how old the repomd.xml (which createrepo creates) is.  We give mirrors one day before marking them outdated.

We're supposed to always have a fallback mirror (the repo server itself) but we perform the same check for its up-to-dateness.  If createrepo has been skipped for long enough, then even the main repo server was considered out of date with the main repo server.

Instead, create sentinel 'last-updated' files that get updated whether createrepo is run or skipped; use that instead of repomd.xml.

Along the way, I dropped the "has the repo migrated from the pre-OSG-23 layout" check because it's out of date.