### PR TITLE
Use snapshot for osg-development instead of alpha

### DIFF
--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -49,25 +49,29 @@ release_repo = 23.0/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-24.x]
-alpha_repo = 24.x/$${EL}/$${ARCH}/alpha -> condor-alpha
+# snapshot is signed with the AUTO key, the others with the DEV key
+snapshot_repo = 24.x/$${EL}/$${ARCH}/snapshot -> condor-snapshot
 beta_repo = 24.x/$${EL}/$${ARCH}/beta -> condor-beta
 release_repo = 24.x/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-24.0]
-alpha_repo = 24.0/$${EL}/$${ARCH}/alpha -> condor-alpha
+# snapshot is signed with the AUTO key, the others with the DEV key
+snapshot_repo = 24.0/$${EL}/$${ARCH}/snapshot -> condor-snapshot
 beta_repo = 24.0/$${EL}/$${ARCH}/beta -> condor-beta
 release_repo = 24.0/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-25.x]
-alpha_repo = 25.x/$${EL}/$${ARCH}/alpha -> condor-alpha
+# snapshot is signed with the AUTO key, the others with the DEV key
+snapshot_repo = 25.x/$${EL}/$${ARCH}/snapshot -> condor-snapshot
 beta_repo = 25.x/$${EL}/$${ARCH}/beta -> condor-beta
 release_repo = 25.x/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-25.0]
-alpha_repo = 25.0/$${EL}/$${ARCH}/alpha -> condor-alpha
+# snapshot is signed with the AUTO key, the others with the DEV key
+snapshot_repo = 25.0/$${EL}/$${ARCH}/snapshot -> condor-snapshot
 beta_repo = 25.0/$${EL}/$${ARCH}/beta -> condor-beta
 release_repo = 25.0/$${EL}/$${ARCH}/release -> condor-release
 
@@ -223,7 +227,7 @@ dest = osg/23-internal/$${EL}/release
 [tagset osg-24-main-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-main/$${EL}/development
-condor_repos = ${condor-24.0:alpha_repo}
+condor_repos = ${condor-24.0:snapshot_repo}
 
 [tagset osg-24-main-$${EL}-testing]
 dvers = el8 el9
@@ -244,7 +248,7 @@ condor_repos = ${condor-24.0:release_repo}
 [tagset osg-24-upcoming-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/development
-condor_repos = ${condor-24.x:alpha_repo}
+condor_repos = ${condor-24.x:snapshot_repo}
 
 [tagset osg-24-upcoming-$${EL}-testing]
 dvers = el8 el9
@@ -287,7 +291,7 @@ dest = osg/24-internal/$${EL}/release
 [tagset osg-25-main-$${EL}-development]
 dvers = el8 el9
 dest = osg/25-main/$${EL}/development
-condor_repos = ${condor-25.0:alpha_repo}
+condor_repos = ${condor-25.0:snapshot_repo}
 
 [tagset osg-25-main-$${EL}-testing]
 dvers = el8 el9
@@ -306,7 +310,7 @@ condor_repos = ${condor-25.0:release_repo}
 arches = x86_64_v2 aarch64 x86_64
 dvers = el10
 dest = osg/25-main/el10/development
-condor_repos = 25.0/el10/$${ARCH}/alpha -> condor-alpha
+condor_repos = 25.0/el10/$${ARCH}/snapshot -> condor-snapshot
 
 [tag osg-25-main-el10-testing]
 arches = x86_64_v2 aarch64 x86_64
@@ -329,7 +333,7 @@ condor_repos = 25.0/el10/$${ARCH}/release -> condor-release
 [tagset osg-25-upcoming-$${EL}-development]
 dvers = el8 el9
 dest = osg/25-upcoming/$${EL}/development
-condor_repos = ${condor-25.x:alpha_repo}
+condor_repos = ${condor-25.x:snapshot_repo}
 
 [tagset osg-25-upcoming-$${EL}-testing]
 dvers = el8 el9
@@ -348,7 +352,7 @@ condor_repos = ${condor-25.x:release_repo}
 arches = x86_64_v2 aarch64 x86_64
 dvers = el10
 dest = osg/25-upcoming/el10/development
-condor_repos = 25.x/el10/$${ARCH}/alpha -> condor-alpha
+condor_repos = 25.x/el10/$${ARCH}/snapshot -> condor-snapshot
 
 [tag osg-25-upcoming-el10-testing]
 arches = x86_64_v2 aarch64 x86_64


### PR DESCRIPTION
We need the RPMs to be signed with the AUTO key.